### PR TITLE
NSA-917 - Add trust proxy setting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,10 @@ const init = async () => {
   }));
   app.use(setCorrelationId(true));
 
+  if (config.hostingEnvironment.env !== 'dev') {
+    app.set('trust proxy', 1);
+  }
+
   const csrf = csurf({
     cookie: {
       secure: true,


### PR DESCRIPTION
To stop issues with session cookies when deployed